### PR TITLE
feat(grpc): Add Vision multimodal messages and rpc (v0.8.0)

### DIFF
--- a/grpc/gradle.properties
+++ b/grpc/gradle.properties
@@ -1,1 +1,1 @@
-version=0.7.6
+version=0.8.0

--- a/grpc/src/main/proto/ai.proto
+++ b/grpc/src/main/proto/ai.proto
@@ -53,6 +53,46 @@ message AiApiResponse {
   bool is_error = 3;
 }
 
+// ============== Vision (Multimodal Image Input) ==============
+
+message BytesImage {
+  bytes data = 1;
+  string mime_type = 2;   // "image/png", "image/jpeg", "image/webp", "image/heic", "image/heif"
+}
+
+message UrlImage {
+  string url = 1;         // Full URL (recommended: Storage presigned URL)
+}
+
+message StorageKeyImage {
+  string bucket = 1;
+  string key = 2;
+}
+
+message ImageInput {
+  oneof source {
+    BytesImage bytes = 1;
+    UrlImage url = 2;
+    StorageKeyImage storage_key = 3;
+  }
+}
+
+message AiVisionRequest {
+  repeated ModelSpec models = 1;
+  repeated ChatMessage messages = 2;
+  repeated ImageInput images = 3;
+  string application_id = 4;
+  optional int32 timeout_seconds = 5;
+  optional int32 max_tokens = 6;
+  optional string request_type = 7;
+}
+
+message AiVisionResponse {
+  Vendor vendor = 1;
+  string result = 2;
+  bool is_error = 3;
+}
+
 // ============== Embedding ==============
 
 message EmbeddingModelSpec {
@@ -92,4 +132,5 @@ message EmbeddingApiResponse {
 service AiApiService {
   rpc Chat(AiApiRequest) returns (AiApiResponse);
   rpc Embedding(EmbeddingApiRequest) returns (EmbeddingApiResponse);
+  rpc Vision(AiVisionRequest) returns (AiVisionResponse);
 }


### PR DESCRIPTION
ai.proto additions for image-input AI calls:
- BytesImage / UrlImage / StorageKeyImage + ImageInput (oneof source)
- AiVisionRequest (models, messages, images, application_id, + optional timeout/maxTokens/requestType)
- AiVisionResponse (vendor, result, is_error)
- AiApiService.Vision rpc

Minor bump 0.7.6 -> 0.8.0 (additive, no breaking change to existing Chat/Embedding rpcs). spring-ai service adapter implementation lands in a follow-up PR; this commit only publishes the schema.